### PR TITLE
Added printing for link position and velocity outputs

### DIFF
--- a/mvnxparser/MVNXStreamReader/MVNXParser.cpp
+++ b/mvnxparser/MVNXStreamReader/MVNXParser.cpp
@@ -145,6 +145,8 @@ int main(int argc, char* argv[])
             + inputFileInfo.baseName().toStdString() + ".csv";
         mvnx.printDataFile(modelCreationDataFile,
                            std::vector<MVNXStreamReader::OutputDataType>{
+                               MVNXStreamReader::OutputDataType::LINK_POSITION,
+                               MVNXStreamReader::OutputDataType::LINK_VELOCITY,
                                MVNXStreamReader::OutputDataType::LINK_ACCELERATION,
                                MVNXStreamReader::OutputDataType::LINK_ORIENTATION,
                                MVNXStreamReader::OutputDataType::LINK_ANGULAR_VELOCITY,


### PR DESCRIPTION
This modification allows to print:
- `MVNXStreamReader::OutputDataType::LINK_POSITION`
- `MVNXStreamReader::OutputDataType::LINK_VELOCITY`

in the output file.